### PR TITLE
Fixed set_data() in animate() in ComputationalHomework08.ipynb for matplotlib==3.9.2 compatibility

### DIFF
--- a/ComputationalHomework08.ipynb
+++ b/ComputationalHomework08.ipynb
@@ -93,7 +93,7 @@
     "        for ipath,(x_array, y_array) in enumerate(zip(x_arrays,y_arrays) ):\n",
     "            x = x_array[frame_num]\n",
     "            y = y_array[frame_num]\n",
-    "            marker[ipath].set_data([x,y])\n",
+    "            marker[ipath].set_data([[x],[y]])\n",
     "            orbit[ipath].set_data([ x_array[:frame_num],y_array[:frame_num] ])\n",
     "        return\n",
     "\n",


### PR DESCRIPTION
Fixed line of code in animate() to make code compatible with matplotlib==3.9.2 since set_data now requires the arguments to have an iterator method. Code was tested for compatibility with matplotlib 3.8.0 and 3.9.2.  This issue was a result of the following commit to the matplotlib software: https://github.com/matplotlib/matplotlib/commit/a9523f5fbc9552d088f7759f918d0c1ab766d236